### PR TITLE
Add minimal specification

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -41,9 +41,7 @@ contributors: Mathias Bynens
         1. Set _searchValue_ to ? RegExpCreate(_escapedPattern_, `"g"`).
       1. Assert: ? IsRegExp(_searchValue_) is *true*.
       1. Let _replacer_ be ? GetMethod(_searchValue_, @@replace).
-      1. If IsCallable(_replacer_) is *true*, then
-        1. Return ? Call(_replacer_, _searchValue_, &laquo; _O_, _replaceValue_ &raquo;).
-      1. Else, throw a *TypeError* exception.
+      1. Return ? Call(_replacer_, _searchValue_, &laquo; _O_, _replaceValue_ &raquo;).
   </emu-alg>
   <emu-note>
     <p>The `replaceAll` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>

--- a/spec.html
+++ b/spec.html
@@ -38,7 +38,7 @@ contributors: Mathias Bynens
       1. Let _searchString_ be ? ToString(_searchValue_).
       1. Set _escapedPattern_ to EscapeRegExpPattern(_src_, `"g"`).
       1. Set _searchValue_ to ? RegExpCreate(_escapedPattern_, `"g"`).
-    1. Assert: ? IsRegExp(_searchValue_) is *true*.
+    1. Assert: ! IsRegExp(_searchValue_) is *true*.
     1. Let _replacer_ be ? GetMethod(_searchValue_, @@replace).
     1. Return ? Call(_replacer_, _searchValue_, &laquo; _O_, _replaceValue_ &raquo;).
   </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -29,24 +29,21 @@ contributors: Mathias Bynens
   <emu-alg>
     1. Let _O_ be ? RequireObjectCoercible(*this* value).
     1. If _searchValue_ is neither *undefined* nor *null*, then
+      1. Let _isRegExp_ be ? IsRegExp(_searchValue_).
+      1. If _isRegExp_ is *true*, then
+        1. Let _flags_ be _searchValue_.[[OriginalFlags]].
+        1. If _flags_ does not contain `"g"`, then
+          1. Set _flags_ to a copy of _flags_.
+          1. Append `"g"` to _flags_.
+      1. Else,
+        1. Let _searchString_ be ? ToString(_searchValue_).
+        1. Set _escapedPattern_ to EscapeRegExpPattern(_src_, `"g"`).
+        1. Set _searchValue_ to ? RegExpCreate(_escapedPattern_, `"g"`).
+      1. Assert: ? IsRegExp(_searchValue_) is *true*.
       1. Let _replacer_ be ? GetMethod(_searchValue_, @@replace).
-      1. If _replacer_ is not *undefined*, then
+      1. If IsCallable(_replacer_) is *true*, then
         1. Return ? Call(_replacer_, _searchValue_, &laquo; _O_, _replaceValue_ &raquo;).
-    1. Let _string_ be ? ToString(_O_).
-    1. Let _searchString_ be ? ToString(_searchValue_).
-    1. Let _functionalReplace_ be IsCallable(_replaceValue_).
-    1. If _functionalReplace_ is *false*, then
-      1. Set _replaceValue_ to ? ToString(_replaceValue_).
-    1. Search _string_ for the first occurrence of _searchString_ and let _pos_ be the index within _string_ of the first code unit of the matched substring and let _matched_ be _searchString_. If no occurrences of _searchString_ were found, return _string_.
-    1. If _functionalReplace_ is *true*, then
-      1. Let _replValue_ be ? Call(_replaceValue_, *undefined*, &laquo; _matched_, _pos_, _string_ &raquo;).
-      1. Let _replStr_ be ? ToString(_replValue_).
-    1. Else,
-      1. Let _captures_ be a new empty List.
-      1. Let _replStr_ be GetSubstitution(_matched_, _string_, _pos_, _captures_, *undefined*, _replaceValue_).
-    1. Let _tailPos_ be _pos_ + the number of code units in _matched_.
-    1. Let _newString_ be the string-concatenation of the first _pos_ code units of _string_, _replStr_, and the trailing substring of _string_ starting at index _tailPos_. If _pos_ is 0, the first element of the concatenation will be the empty String.
-    1. Return _newString_.
+      1. Else, throw a *TypeError* exception.
   </emu-alg>
   <emu-note>
     <p>The `replaceAll` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>

--- a/spec.html
+++ b/spec.html
@@ -28,20 +28,19 @@ contributors: Mathias Bynens
   <p>When the `replaceAll` method is called with arguments _searchValue_ and _replaceValue_, the following steps are taken:</p>
   <emu-alg>
     1. Let _O_ be ? RequireObjectCoercible(*this* value).
-    1. If _searchValue_ is neither *undefined* nor *null*, then
-      1. Let _isRegExp_ be ? IsRegExp(_searchValue_).
-      1. If _isRegExp_ is *true*, then
-        1. Let _flags_ be _searchValue_.[[OriginalFlags]].
-        1. If _flags_ does not contain `"g"`, then
-          1. Set _flags_ to a copy of _flags_.
-          1. Append `"g"` to _flags_.
-      1. Else,
-        1. Let _searchString_ be ? ToString(_searchValue_).
-        1. Set _escapedPattern_ to EscapeRegExpPattern(_src_, `"g"`).
-        1. Set _searchValue_ to ? RegExpCreate(_escapedPattern_, `"g"`).
-      1. Assert: ? IsRegExp(_searchValue_) is *true*.
-      1. Let _replacer_ be ? GetMethod(_searchValue_, @@replace).
-      1. Return ? Call(_replacer_, _searchValue_, &laquo; _O_, _replaceValue_ &raquo;).
+    1. Let _isRegExp_ be ? IsRegExp(_searchValue_).
+    1. If _isRegExp_ is *true*, then
+      1. Let _flags_ be _searchValue_.[[OriginalFlags]].
+      1. If _flags_ does not contain `"g"`, then
+        1. Set _flags_ to a copy of _flags_.
+        1. Append `"g"` to _flags_.
+    1. Else,
+      1. Let _searchString_ be ? ToString(_searchValue_).
+      1. Set _escapedPattern_ to EscapeRegExpPattern(_src_, `"g"`).
+      1. Set _searchValue_ to ? RegExpCreate(_escapedPattern_, `"g"`).
+    1. Assert: ? IsRegExp(_searchValue_) is *true*.
+    1. Let _replacer_ be ? GetMethod(_searchValue_, @@replace).
+    1. Return ? Call(_replacer_, _searchValue_, &laquo; _O_, _replaceValue_ &raquo;).
   </emu-alg>
   <emu-note>
     <p>The `replaceAll` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>


### PR DESCRIPTION
[**diff sans whitespace**](https://github.com/tc39/proposal-string-replace-all/pull/13/files?w=1)

This is the smallest possible delta compared to `String#replace` that I could think of. This approach takes the _searchValue_ and turns it into a global regular expression if it isn't already, carefully escaping special characters when needed. It throws when `RegExp.prototype[Symbol.replace]` is not callable (e.g. when it has been [deleted](https://github.com/tc39/proposal-string-matchall/issues/39)).

This way, we avoid the introduction of `RegExp.prototype[Symbol.replaceAll]` which would basically do the same thing as `RegExp.prototype[Symbol.replace]` for global regular expressions anyway.

Thoughts? @psmarshall @schuay @ljharb